### PR TITLE
Add GitHub Actions script.

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -69,7 +69,7 @@ jobs:
 
       # Upload to release
       - name: Upload images to release
-        uses: softprops/action-gh-release@v1
+        uses: softprops/action-gh-release@v0.1.6
         if: startsWith(github.ref, 'refs/tags/')
         with:
           files: |
@@ -77,3 +77,5 @@ jobs:
             rpi-2-archlinux.img.zip
             rpi-4-archlinux.img.zip
             rpi-aarch64-archlinux.img.zip
+        env:
+          GITHUB_TOKEN: ${{ github.token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,79 @@
+name: Build images
+
+on:
+  push:
+  workflow_dispatch:
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install dependencies
+        run: |
+          sudo apt update
+          sudo apt upgrade
+          sudo apt install parted wget dosfstools zip
+
+      # Build Images
+      # Note: Uploading zip file artifact will be double zip. Do not delete .img file
+      # See https://github.com/actions/upload-artifact#zipped-artifact-downloads
+      - name: Build Raspberry Pi Image
+        run: |
+          sudo bash create-image rpi
+          zip -v rpi-archlinux.img.zip rpi-archlinux.img
+
+      - name: Build Raspberry Pi 2/3 Image
+        run: |
+          sudo bash create-image rpi-2
+          zip -v rpi-2-archlinux.img.zip rpi-2-archlinux.img
+
+      - name: Build Raspberry Pi 4 Image
+        run: |
+          sudo bash create-image rpi-4
+          zip -v rpi-4-archlinux.img.zip rpi-4-archlinux.img
+
+      # Note: This won't work on RPi4 as it need to modify /etc/fstab.
+      - name: Build Raspberry Pi AArch64 Image
+        run: |
+          sudo bash create-image rpi-aarch64
+          zip -v rpi-aarch64-archlinux.img.zip rpi-aarch64-archlinux.img
+
+
+      # Upload artifacts
+      - name: Upload Raspberry Pi Image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpi-archlinux.img
+          path: rpi-archlinux.img
+      
+      - name: Upload Raspberry Pi 2/3 Image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpi-2-archlinux.img
+          path: rpi-2-archlinux.img
+
+      - name: Upload Raspberry Pi 4 Image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpi-4-archlinux.img
+          path: rpi-4-archlinux.img
+
+      - name: Upload Raspberry Pi AArch64 Image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpi-aarch64-archlinux.img
+          path: rpi-aarch64-archlinux.img
+
+
+      # Upload to release
+      - name: Upload images to release
+        uses: softprops/action-gh-release@v1
+        if: startsWith(github.ref, 'refs/tags/')
+        with:
+          files: |
+            rpi-archlinux.img.zip
+            rpi-2-archlinux.img.zip
+            rpi-4-archlinux.img.zip
+            rpi-aarch64-archlinux.img.zip

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -34,11 +34,25 @@ jobs:
           sudo bash create-image rpi-4
           zip -v rpi-4-archlinux.img.zip rpi-4-archlinux.img
 
-      # Note: This won't work on RPi4 as it need to modify /etc/fstab.
-      - name: Build Raspberry Pi AArch64 Image
+      - name: Build Raspberry Pi 3 AArch64 Image
         run: |
           sudo bash create-image rpi-aarch64
-          zip -v rpi-aarch64-archlinux.img.zip rpi-aarch64-archlinux.img
+          sudo cp rpi-aarch64-archlinux.img rpi-3-aarch64-archlinux.img
+          zip -v rpi-3-aarch64-archlinux.img.zip rpi-3-aarch64-archlinux.img
+
+      - name: Build Raspberry Pi 4 AArch64 Image
+        run: |
+          sudo cp rpi-aarch64-archlinux.img rpi-4-aarch64-archlinux.img
+
+          mkdir root
+          loopdev=$(sudo losetup --find --show rpi-4-aarch64-archlinux.img)
+          rootdev=$(sudo ls "${loopdev}"*2)
+          sudo mount "${rootdev}" root
+          sudo sed -i 's/mmcblk0/mmcblk1/g' root/etc/fstab
+          sudo umount root
+          sudo rmdir root
+
+          zip -v rpi-4-aarch64-archlinux.img.zip rpi-4-aarch64-archlinux.img
 
 
       # Upload artifacts
@@ -60,11 +74,17 @@ jobs:
           name: rpi-4-archlinux.img
           path: rpi-4-archlinux.img
 
-      - name: Upload Raspberry Pi AArch64 Image artifact
+      - name: Upload Raspberry Pi 3 AArch64 Image artifact
         uses: actions/upload-artifact@v2
         with:
-          name: rpi-aarch64-archlinux.img
-          path: rpi-aarch64-archlinux.img
+          name: rpi-3-aarch64-archlinux.img
+          path: rpi-3-aarch64-archlinux.img
+
+      - name: Upload Raspberry Pi 4 AArch64 Image artifact
+        uses: actions/upload-artifact@v2
+        with:
+          name: rpi-4-aarch64-archlinux.img
+          path: rpi-4-aarch64-archlinux.img
 
 
       # Upload to release
@@ -76,6 +96,7 @@ jobs:
             rpi-archlinux.img.zip
             rpi-2-archlinux.img.zip
             rpi-4-archlinux.img.zip
-            rpi-aarch64-archlinux.img.zip
+            rpi-3-aarch64-archlinux.img.zip
+            rpi-4-aarch64-archlinux.img.zip
         env:
           GITHUB_TOKEN: ${{ github.token }}

--- a/README.md
+++ b/README.md
@@ -28,10 +28,13 @@ Then follow the standard instructions for your operating system to burn the imag
 - [rpi-2-archlinux.img.zip](https://github.com/andrewboring/alarm-images/releases/latest/download/rpi-2-archlinux.img.zip): For ARMv7, with the Raspberry Pi firmware. Also works on Raspberry Pi 3 series. Use this if you need VC4 stuff (like the GPU).
   - Upstream: https://archlinuxarm.org/platforms/armv7/broadcom/raspberry-pi-2
 
-- [rpi-4-archlinux.img.zip](https://github.com/andrewboring/alarm-images/releases/latest/download/rpi-3-archlinux.img.zip): Supplies ARMv7 kernel and RPi firmware, at the moment. Use RPI-3 above if you want aarch64 support.
+- [rpi-4-archlinux.img.zip](https://github.com/andrewboring/alarm-images/releases/latest/download/rpi-3-archlinux.img.zip): Supplies ARMv7 kernel and RPi firmware, at the moment. Use below if you want aarch64 support.
   - Upstream: https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-4
 
-- [aarch64-archlinux.img.zip](https://github.com/andrewboring/alarm-images/releases/latest/download/aarh64-archlinux.img.zip): For ARMv8/Aarch64, works on RPI3/4, with Uboot and Mainline Linux kernel.
+- [rpi-3-aarch64-archlinux.img.zip](https://github.com/andrewboring/alarm-images/releases/latest/download/rpi-3-aarh64-archlinux.img.zip): For ARMv8/Aarch64, works on RPI3, with Uboot and Mainline Linux kernel.
+  - Upstream: https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-3
+
+- [rpi-4-aarch64-archlinux.img.zip](https://github.com/andrewboring/alarm-images/releases/latest/download/rpi-4-aarh64-archlinux.img.zip): For RPI4 ARMv8/Aarch64. A patched version of RPI3 Aarch64 for RPI4 to boot correctly.
   - Upstream: https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-4
 
 [ to do: add more details on ARMv7 vs ARMv8 vs aarch32 vs aarch64 ]

--- a/create-image
+++ b/create-image
@@ -49,8 +49,8 @@ echo Downloading ${file}
 fallocate -l "${size}" "${image}"
 loopdev=$(losetup --find --show "${image}")
 parted --script "${loopdev}" mklabel msdos
-parted --script "${loopdev}" mkpart primary fat32 0% 100M
-parted --script "${loopdev}" mkpart primary ext4 100M 100%
+parted --script "${loopdev}" mkpart primary fat32 0% 200M
+parted --script "${loopdev}" mkpart primary ext4 200M 100%
 bootdev=$(ls "${loopdev}"*1)
 rootdev=$(ls "${loopdev}"*2)
 mkfs.vfat -F32 ${bootdev}


### PR DESCRIPTION
Since Travis is discontinued, I just made a github actions script to build image automatically.
Also, I edited `create-image` to follow ALArm's recommendation. (200M is recommended. Also, AArch64 requires over 100M)

Preview
For Artifacts: https://github.com/MPThLee/alarm-images/actions/runs/1069065328
For Release: https://github.com/MPThLee/alarm-images/releases/tag/2021.07.27-RPi4-Aarch64

# Limitation
 * Release upload requires tag.
 * Artifacts upload will be deleted after retention days(90 days in gha default.)
 * Artifacts size are shown as 8GB, (However, Actual downloaded file is zipped ~600MB.)
    - Artifacts uploaded without zipping due to actions bug. See [actions/upload-artifacts](https://github.com/actions/upload-artifact#zipped-artifact-downloads)
 * Default ALArm RPi-AArch64 Image won't boot up on rpi4 as it requires additional step.
    - It has different SD block device compared to rpi3. (`sed -i 's/mmcblk0/mmcblk1/g' root/etc/fstab` for rpi4)
    - See Installation on [ALArm RPi4 page](https://archlinuxarm.org/platforms/armv8/broadcom/raspberry-pi-4)
    - I patched this on actions with bit hacky way. 